### PR TITLE
Fix for mismatching partials

### DIFF
--- a/resources/cask.rb
+++ b/resources/cask.rb
@@ -10,5 +10,5 @@ attribute :options,
   kind_of: String
 
 def casked?
-  shell_out("/usr/local/bin/brew cask list | grep #{name}").exitstatus == 0
+  shell_out('/usr/local/bin/brew cask list 2>/dev/null').stdout.split.include?(name)
 end


### PR DESCRIPTION
This should prevent partial matches. Leave Ruby to do the matching.

For example, `vagrant-manager` was not getting installed due to the presence of `vagrant`.
